### PR TITLE
feat: Added 1.21.10 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.8-SNAPSHOT'
+	id 'fabric-loom' version "${loom_version}"
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,15 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
-loader_version=0.16.10
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.2
+loader_version=0.17.3
+loom_version=1.11-SNAPSHOT
 
 # Mod Properties
-mod_version=1.4.2
+mod_version=1.4.3
 maven_group=com.aguga
 archives_base_name=chest-logs
 
 # Dependencies
-fabric_version=0.115.1+1.21.4
+fabric_version=0.136.0+1.21.10

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/aguga/Utils/ChestClosedCallback.java
+++ b/src/main/java/com/aguga/Utils/ChestClosedCallback.java
@@ -2,18 +2,16 @@ package com.aguga.Utils;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
-import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.ContainerUser;
+import net.minecraft.server.network.ServerPlayerEntity;
 
 @FunctionalInterface
-public interface ChestClosedCallback
-{
-    void invoke(PlayerEntity player);
+public interface ChestClosedCallback {
+    void invoke(ContainerUser player);
 
     Event<ChestClosedCallback> EVENT = EventFactory.createArrayBacked(ChestClosedCallback.class,
-            (listeners) -> (player) ->
-            {
-                for (ChestClosedCallback listener : listeners)
-                {
+            (listeners) -> (player) -> {
+                for (ChestClosedCallback listener : listeners) {
                     listener.invoke(player);
                 }
             });

--- a/src/main/java/com/aguga/mixin/BarrelBlockEntityMixin.java
+++ b/src/main/java/com/aguga/mixin/BarrelBlockEntityMixin.java
@@ -2,18 +2,17 @@ package com.aguga.mixin;
 
 import com.aguga.Utils.ChestClosedCallback;
 import net.minecraft.block.entity.BarrelBlockEntity;
-import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.ContainerUser;
+import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BarrelBlockEntity.class)
-public class BarrelBlockEntityMixin
-{
+public class BarrelBlockEntityMixin {
     @Inject(at = @At("TAIL"), method = "onClose")
-    public void onClose(PlayerEntity player, CallbackInfo ci)
-    {
+    public void onClose(ContainerUser player, CallbackInfo ci) {
         ChestClosedCallback.EVENT.invoker().invoke(player);
     }
 }

--- a/src/main/java/com/aguga/mixin/ChestBlockEntityMixin.java
+++ b/src/main/java/com/aguga/mixin/ChestBlockEntityMixin.java
@@ -2,18 +2,17 @@ package com.aguga.mixin;
 
 import com.aguga.Utils.ChestClosedCallback;
 import net.minecraft.block.entity.ChestBlockEntity;
-import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.ContainerUser;
+import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ChestBlockEntity.class)
-public class ChestBlockEntityMixin
-{
+public class ChestBlockEntityMixin {
     @Inject(at = @At("TAIL"), method = "onClose")
-    public void onClose(PlayerEntity player, CallbackInfo ci)
-    {
+    public void onClose(ContainerUser player, CallbackInfo ci) {
         ChestClosedCallback.EVENT.invoker().invoke(player);
     }
 }

--- a/src/main/java/com/aguga/mixin/ShulkerBoxBlockEntityMixin.java
+++ b/src/main/java/com/aguga/mixin/ShulkerBoxBlockEntityMixin.java
@@ -2,18 +2,17 @@ package com.aguga.mixin;
 
 import com.aguga.Utils.ChestClosedCallback;
 import net.minecraft.block.entity.ShulkerBoxBlockEntity;
-import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.ContainerUser;
+import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ShulkerBoxBlockEntity.class)
-public class ShulkerBoxBlockEntityMixin
-{
+public class ShulkerBoxBlockEntityMixin {
     @Inject(at = @At("TAIL"), method = "onClose")
-    public void onClose(PlayerEntity player, CallbackInfo ci)
-    {
+    public void onClose(ContainerUser player, CallbackInfo ci) {
         ChestClosedCallback.EVENT.invoker().invoke(player);
     }
 }

--- a/src/main/resources/chest-logs.mixins.json
+++ b/src/main/resources/chest-logs.mixins.json
@@ -1,14 +1,14 @@
 {
-  "required": true,
-  "package": "com.aguga.mixin",
-  "compatibilityLevel": "JAVA_17",
-  "mixins": [
-    "BarrelBlockEntityMixin",
-    "ChestBlockEntityMixin",
-    "ShulkerBoxBlockEntityMixin",
-    "PlayerPlaceBlock"
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  }
+	"required": true,
+	"package": "com.aguga.mixin",
+	"compatibilityLevel": "JAVA_21",
+	"mixins": [
+		"BarrelBlockEntityMixin",
+		"ChestBlockEntityMixin",
+		"ShulkerBoxBlockEntityMixin",
+		"PlayerPlaceBlock"
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,9 +4,7 @@
 	"version": "${version}",
 	"name": "Chest Logs",
 	"description": "Log all chests on your server to catch the thieves",
-	"authors": [
-		"Aguga2201"
-	],
+	"authors": ["Aguga2201"],
 	"contact": {
 		"homepage": "https://github.com/Aguga2201/ChestLog",
 		"sources": "https://github.com/Aguga2201/ChestLog",
@@ -16,16 +14,12 @@
 	"icon": "assets/chest-log/icon.png",
 	"environment": "*",
 	"entrypoints": {
-		"main": [
-          "com.aguga.ChestLogs"
-		]
+		"main": ["com.aguga.ChestLogs"]
 	},
-	"mixins": [
-		"chest-logs.mixins.json"
-	],
+	"mixins": ["chest-logs.mixins.json"],
 	"depends": {
 		"fabricloader": ">=0.16.9",
-		"minecraft": ">=1.21.3 <=1.21.4",
+		"minecraft": ">=1.21.3 <=1.21.10",
 		"java": ">=21",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
This pull request updates the mod for compatibility with Minecraft 1.21.10 and Java 21, refactors code for improved readability and consistency, and updates dependencies to their latest versions. The most significant changes are grouped below:

**Compatibility and Dependency Updates**

* Upgraded Minecraft version to 1.21.10, Fabric API to 0.136.0+1.21.10, Yarn mappings, Loader, Loom, and Gradle to their latest compatible versions in `gradle.properties` and `gradle-wrapper.properties`. Updated mod version to 1.4.3. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L7-R18) [[2]](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3)
* Updated `fabric.mod.json` to reflect new Minecraft version support (up to 1.21.10), Java 21 requirement, and streamlined JSON formatting. [[1]](diffhunk://#diff-882c6606823cf6c4e4114c1125850a04ed3180c48aef0e1467f1e4022b235db2L7-R7) [[2]](diffhunk://#diff-882c6606823cf6c4e4114c1125850a04ed3180c48aef0e1467f1e4022b235db2L19-R22)
* Changed mixin compatibility level to Java 21 in `chest-logs.mixins.json`.

**Code Refactoring and API Migration**

* Refactored `ChestLogs.java` for improved readability: used consistent brace style, reformatted long lines, and updated event callback logic for better clarity. [[1]](diffhunk://#diff-b1a94478a4e038173c9931d48626762f95f5e64c3de2b83b01f2e9f33d6347bdL30-R46) [[2]](diffhunk://#diff-b1a94478a4e038173c9931d48626762f95f5e64c3de2b83b01f2e9f33d6347bdL58-R57) [[3]](diffhunk://#diff-b1a94478a4e038173c9931d48626762f95f5e64c3de2b83b01f2e9f33d6347bdL74-R84) [[4]](diffhunk://#diff-b1a94478a4e038173c9931d48626762f95f5e64c3de2b83b01f2e9f33d6347bdL107-R126) [[5]](diffhunk://#diff-b1a94478a4e038173c9931d48626762f95f5e64c3de2b83b01f2e9f33d6347bdL143-R137) [[6]](diffhunk://#diff-b1a94478a4e038173c9931d48626762f95f5e64c3de2b83b01f2e9f33d6347bdL153-R155)
* Updated mixin classes (`BarrelBlockEntityMixin`, `ChestBlockEntityMixin`, `ShulkerBoxBlockEntityMixin`) and `ChestClosedCallback` interface to use `ContainerUser` instead of `PlayerEntity`, aligning with newer Fabric API conventions. [[1]](diffhunk://#diff-f89e8ab8d46ed8249e22ecc687a218a4f3e3f92a5d2a5165e0ca1e1a85818ea8L5-R14) [[2]](diffhunk://#diff-98811b4b64ea134898b45357b8109b19cf0f64565b48319c667fe8ac44da9cd9L5-R15) [[3]](diffhunk://#diff-baad8a061315732faf1fdb01681ee7c6378b7f2b62b15d528e6fa95dd4551f3bL5-R15) [[4]](diffhunk://#diff-57a7e8fd4e7d3e5ab8eb7eee5fba778e9486cdc73b6ff975a62d9c709c13ca1cL5-R15)

These changes ensure the mod remains compatible with the latest Minecraft and Java versions, while also improving code maintainability and future-proofing event handling.